### PR TITLE
Allow configuring location of TLS CA file for Mongo connection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ FROM node:14-alpine
 ENV NODE_ENV=production \
   MONGODB_URI=mongodb://mongodb \
   COLLECTION=agendaJobs \
-  BASE_PATH=/
+  BASE_PATH=/ \
+  MONGO_TLS_CA_FILE=
 
 RUN mkdir -p /agendash
 WORKDIR /agendash

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+# unreleased
+
+- feat: Allow configuring TLS CA file for Mongo connection
+
 # 3.1.0
 
 - Add Content-Security-Policy header to all server implementations

--- a/bin/agendash-standalone-fastify.js
+++ b/bin/agendash-standalone-fastify.js
@@ -31,6 +31,10 @@ program
     "[optional] Path to bind Agendash to, default /",
     "/"
   )
+  .option(
+    "-C, --mongoTLSCaFile <path>",
+    "[optional] Absolute or relative path to TLS CA file, default is unset"
+  )
   .parse(process.argv);
 
 if (!program.db) {
@@ -45,7 +49,14 @@ if (!program.path.startsWith("/")) {
 
 const fastify = Fastify();
 
-const agenda = new Agenda().database(program.db, program.collection);
+let databaseOptions = {};
+if (program.mongoTLSCaFile && program.mongoTLSCaFile.length > 0) {
+  databaseOptions.tlsCAFile = program.mongoTLSCaFile;
+  // This seems to be required to be true here even if the Mongo URI defines ssl/tls
+  databaseOptions.tls = true;
+}
+
+const agenda = new Agenda().database(program.db, program.collection, databaseOptions);
 
 fastify.register(
   agendash(agenda, {

--- a/bin/agendash-standalone-hapi.js
+++ b/bin/agendash-standalone-hapi.js
@@ -26,6 +26,10 @@ program
     "[optional] Page title, default Agendash",
     "Agendash"
   )
+  .option(
+    "-C, --mongoTLSCaFile <path>",
+    "[optional] Absolute or relative path to TLS CA file, default is unset"
+  )
   .parse(process.argv);
 
 if (!program.db) {
@@ -39,7 +43,14 @@ const init = async () => {
     host: "localhost",
   });
 
-  const agenda = new Agenda().database(program.db, program.collection);
+  let databaseOptions = {};
+  if (program.mongoTLSCaFile && program.mongoTLSCaFile.length > 0) {
+    databaseOptions.tlsCAFile = program.mongoTLSCaFile;
+    // This seems to be required to be true here even if the Mongo URI defines ssl/tls
+    databaseOptions.tls = true;
+  }
+
+  const agenda = new Agenda().database(program.db, program.collection, databaseOptions);
 
   await server.register(require("@hapi/inert"));
   await server.register(

--- a/bin/agendash-standalone-koa.js
+++ b/bin/agendash-standalone-koa.js
@@ -26,6 +26,10 @@ program
     "[optional] Page title, default Agendash",
     "Agendash"
   )
+  .option(
+    "-C, --mongoTLSCaFile <path>",
+    "[optional] Absolute or relative path to TLS CA file, default is unset"
+  )
   .parse(process.argv);
 
 if (!program.db) {
@@ -34,7 +38,14 @@ if (!program.db) {
 }
 
 const init = async () => {
-  const agenda = new Agenda().database(program.db, program.collection);
+  let databaseOptions = {};
+  if (program.mongoTLSCaFile && program.mongoTLSCaFile.length > 0) {
+    databaseOptions.tlsCAFile = program.mongoTLSCaFile;
+    // This seems to be required to be true here even if the Mongo URI defines ssl/tls
+    databaseOptions.tls = true;
+  }
+
+  const agenda = new Agenda().database(program.db, program.collection, databaseOptions);
 
   const app = new Koa();
   const middlewares = agendash(agenda, {

--- a/bin/agendash-standalone.js
+++ b/bin/agendash-standalone.js
@@ -32,6 +32,10 @@ program
     "[optional] Path to bind Agendash to, default /",
     "/"
   )
+  .option(
+    "-C, --mongoTLSCaFile <path>",
+    "[optional] Absolute or relative path to TLS CA file, default is unset"
+  )
   .parse(process.argv);
 
 if (!program.db) {
@@ -46,7 +50,14 @@ if (!program.path.startsWith("/")) {
 
 const app = express();
 
-const agenda = new Agenda().database(program.db, program.collection);
+let databaseOptions = {};
+if (program.mongoTLSCaFile && program.mongoTLSCaFile.length > 0) {
+  databaseOptions.tlsCAFile = program.mongoTLSCaFile;
+  // This seems to be required to be true here even if the Mongo URI defines ssl/tls
+  databaseOptions.tls = true;
+}
+
+const agenda = new Agenda().database(program.db, program.collection, databaseOptions);
 app.use(
   program.path,
   agendash(agenda, {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,4 @@
 
 set +e
 
-exec node ./bin/agendash-standalone.js --db=$MONGODB_URI --collection=$COLLECTION --path=$BASE_PATH
+exec node ./bin/agendash-standalone.js --db=$MONGODB_URI --collection=$COLLECTION --path=$BASE_PATH --mongoTLSCaFile=$MONGO_TLS_CA_FILE


### PR DESCRIPTION
Flag is -C or --mongoTLSCaFile. Dockerfile also allows specifying MONGO_TLS_CA_FILE as an environment variable when running Agendash.

Upstream pr once merged and tested in fork.